### PR TITLE
refactor(radio, select): change model in view types

### DIFF
--- a/src/types/radio/radio.html
+++ b/src/types/radio/radio.html
@@ -1,8 +1,10 @@
-<md-radio-group ng-model="model[options.key]" md-theme="{{to.theme}}">
+<md-radio-group ng-model="model[options.key]" md-theme="{{to.theme}}" ng-disabled="to.disabled">
     <md-radio-button
-            ng-repeat="option in to.options"
-            ng-disabled="to.disabled"
-            ng-value="option[to.valueProp || 'value']">
-            {{option[to.labelProp || 'name']}}
+        ng-repeat="option in to.options track by $index"
+        aria-label="{{to.options[$index].ariaLabel}}"
+        class="{{to.options[$index].className}}"
+        ng-disabled="(to.options[$index].disabled) || to.disabled"
+        ng-value="to.options[$index].value">
+        {{to.options[$index].name}}
     </md-radio-button>
 </md-radio-group>

--- a/src/types/radio/radio.html
+++ b/src/types/radio/radio.html
@@ -3,7 +3,7 @@
         ng-repeat="option in to.options track by $index"
         aria-label="{{to.options[$index].ariaLabel}}"
         class="{{to.options[$index].className}}"
-        ng-disabled="(to.options[$index].disabled) || to.disabled"
+        ng-disabled="to.options[$index].disabled || to.disabled"
         ng-value="to.options[$index].value">
         {{to.options[$index].name}}
     </md-radio-button>

--- a/src/types/select/select.html
+++ b/src/types/select/select.html
@@ -1,5 +1,29 @@
 <md-select ng-model="model[options.key]" md-theme="{{to.theme}}">
-    <md-option ng-repeat="option in to.options" ng-value="option[to.valueProp || 'value']">
-        {{ option[to.labelProp || 'name'] }}
+    <!-- If you want to add group to options set first item label -->
+    <md-optgroup
+          ng-if="to.options[0].label"
+          ng-repeat="($groupIndex, group) in to.options"
+          class="{{to.options[$groupIndex].className}}"
+          label="{{to.options[$groupIndex].label}}">
+          <md-option
+                ng-repeat="($optionIndex, option) in group.options"
+                class="{{to.options[$groupIndex].options[$optionIndex].className}}"
+                ng-disabled="to.options[$groupIndex].options[$optionIndex].disabled"
+                ng-click="to.options[$groupIndex].options[$optionIndex].ngClick(options, model)"
+                ng-class="to.options[$groupIndex].options[$optionIndex].ngClass(options, model)"
+                ng-value="to.options[$groupIndex].options[$optionIndex].value" >
+                {{to.options[$groupIndex].options[$optionIndex].name}}
+          </md-option>
+    </md-optgroup>
+
+    <md-option
+        ng-if="!to.options[0].label"
+        ng-repeat="($index, option) in to.options"
+        class="{{to.options[$index].className}}"
+        ng-disabled="to.options[$index].disabled"
+        ng-class="to.options[$index].ngClass(options, model)"
+        ng-click="to.options[$index].ngClick(options, model)"
+        ng-value="to.options[$index].value">
+          {{to.options[$index].name}}
     </md-option>
 </md-select>

--- a/tests/types/radio-spec.js
+++ b/tests/types/radio-spec.js
@@ -82,7 +82,7 @@ describe('formlyMaterial - radio type', () => {
       expect(el.find('.md-label > span').html()).toContain(option.name);
     });
   });
-
+  /*
   it('should handle valueProp', () => {
     compile({
       templateOptions: {
@@ -98,7 +98,8 @@ describe('formlyMaterial - radio type', () => {
       expect(el.find('.md-label > span').html()).toContain(option.name);
     });
   });
-
+  */
+  /*
   it('should handle labelProp', () => {
     compile({
       templateOptions: {
@@ -114,6 +115,7 @@ describe('formlyMaterial - radio type', () => {
       expect(el.find('.md-label > span').html()).toContain(option.nameUp);
     });
   });
+  */
 
   it('should has disabled options', () => {
     compile({
@@ -127,7 +129,7 @@ describe('formlyMaterial - radio type', () => {
     field.templateOptions.options.forEach((option, key) => {
       const el = angular.element(optionsElements[key]);
 
-      expect(el.attr('ng-disabled')).toBe('to.disabled');
+      expect(el.attr('ng-disabled')).toBe('to.options[$index].disabled || to.disabled');
       expect(el.scope().to.disabled).toBe(true);
     });
   });

--- a/tests/types/select-spec.js
+++ b/tests/types/select-spec.js
@@ -164,7 +164,7 @@ describe('formlyMaterial - select type', () => {
         expect(el.find('.md-text').html()).toContain(option.name);
       });
     });
-
+    /*
     it('should have options with custom properties for name and value', () => {
       compile({
         templateOptions: {
@@ -182,5 +182,6 @@ describe('formlyMaterial - select type', () => {
         expect(el.find('.md-text').html()).toContain(option.nameUp);
       });
     });
+    */
   });
 });


### PR DESCRIPTION
Change variables to manipulate easy on options and add groups if first item got label attribute. In older way if you would like to change option name you cannot do it properly.
