### PR TITLE
Updated package versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,11 +28,7 @@
     "webpack.config.js"
   ],
   "dependencies": {
-    "angular": "~1.4.0",
-    "angular-messages": "~1.4.0",
-    "angular-animate": "~1.4.0",
-    "angular-aria": "~1.4.0",
-    "angular-material": "~1.0.0",
-    "angular-formly": "~7.3.0"
+    "angular-material": "~1.1.0",
+    "angular-formly": "~8.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,12 +35,8 @@
   },
   "homepage": "https://github.com/formly-js/angular-formly-templates-material#readme",
   "dependencies": {
-    "angular": ">= 1.4.0-beta.0 || >= 1.5.0-beta.0",
-    "angular-messages": ">= 1.4.0-beta.0 || >= 1.5.0-beta.0",
-    "angular-animate": ">= 1.4.0-beta.0 || >= 1.5.0-beta.0",
-    "angular-aria": ">= 1.4.0-beta.0 || >= 1.5.0-beta.0",
-    "angular-material": "^1.0.0",
-    "angular-formly": ">=7.3.0",
+    "angular-material": "^1.1.0",
+    "angular-formly": ">=8.3.0",
     "api-check": ">=7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Removed the angular dependencies because they are pulled in by angular-material
and we don't depend on them directly.  This will help resolve some of the
conflicts.  Upgraded to angular-material 1.1.0 which is the latest stable
release as well as angular-formly.  The only breaking change from 7 to 8 does
not affect this project.
