### PR TITLE
feat: allow specification of maxlength from textarea element

### DIFF
--- a/dist/formly-material.js
+++ b/dist/formly-material.js
@@ -947,6 +947,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	        },
 	        cols: {
 	          attribute: 'cols'
+	        },
+	        maxlength: {
+	          attribute: 'md-maxlength'
 	        }
 	      },
 	      templateOptions: {

--- a/docs/types/textarea.md
+++ b/docs/types/textarea.md
@@ -29,6 +29,11 @@ textarea
 
 #### templateOptions.className _: string | expression | array_
 
+#### templateOptions.maxlength *: integer*
+
+The maximum number of characters allowed in this input. If this is specified, a character counter will be shown underneath the input.
+Equivalent to md-maxlength
+
 #### templateOptions.rows *: integer*
 
 Number of rows

--- a/src/types/textarea/textarea.js
+++ b/src/types/textarea/textarea.js
@@ -16,6 +16,9 @@ export default (formlyConfigProvider) => {
         },
         cols: {
           attribute: 'cols'
+        },
+        maxlength: {
+          attribute: 'md-maxlength'
         }
       },
       templateOptions: {


### PR DESCRIPTION
Hey,

Thanks for all the great work on this. I needed the md-maxlength attribute on the textarea type so went ahead and added it to the source file and also the unminified dist file.

I tried running `npm run build` but it seemed to add some additional changes which I hadn't made, so to be safe I thought it should just made this basic PR.

Cheers,
Gary
