### PR TITLE
fix: add missing comma from input example

### DIFF
--- a/docs/types/input.md
+++ b/docs/types/input.md
@@ -14,7 +14,7 @@ Example
   templateOptions: {
     type: "text",
     label: "First name",
-    pattern: "[a-zA-Z]+"
+    pattern: "[a-zA-Z]+",
     theme: "custom"
   }
 }


### PR DESCRIPTION
Simple update. Just missing a comma in an example.